### PR TITLE
Adjust config file path for Proxmox version 2 clusters

### DIFF
--- a/bin/kvm-clone
+++ b/bin/kvm-clone
@@ -7,6 +7,7 @@ import subprocess
 import logging
 import optparse
 
+from socket import gethostname
 from proxmox_utils import KVMUtils, ShellUtils
                     
 def main():
@@ -35,6 +36,7 @@ def main():
   # ---------------------------------------------------------------
   path_from = KVMUtils.image_path(id_from)
   path_to = KVMUtils.image_path(id_to)
+  hostname = gethostname()
 
   # ---------------------------------------------------------------
   # Check paths
@@ -69,7 +71,7 @@ def main():
   # Copy configuration file
   # ---------------------------------------------------------------
   logging.info("Copying configuration file...")
-  ShellUtils.command(["cp", "/etc/qemu-server/" + id_from + ".conf",  "/etc/qemu-server/" + id_to + ".conf"])
+  ShellUtils.command(["cp", "/etc/pve/nodes/" + hostname + "/qemu-server/" + id_from + ".conf",  "/etc/pve/nodes/" + hostname + "/qemu-server/" + id_to + ".conf"])
   logging.info("Copying done")
 
   # ---------------------------------------------------------------

--- a/bin/kvm-create-template
+++ b/bin/kvm-create-template
@@ -33,16 +33,11 @@ def main():
   # ---------------------------------------------------------------
   # Determine paths
   # ---------------------------------------------------------------
-  source_image_path = "/var/lib/vz/images/" + id_from
-  target_image_path = "/var/lib/vz/images/t_" + template_name
-  source_config_path = "/etc/qemu-server/%s.conf" % id_from
-  target_config_path = "/etc/qemu-server/t_%s.conf" % template_name
-
   source_image_path = KVMUtils.image_path(id_from)
   target_image_path = KVMUtils.tpl_image_path(template_name)
   source_config_path = KVMUtils.config_path(id_from)
   target_config_path = KVMUtils.tpl_config_path(template_name)
-  
+
   # ---------------------------------------------------------------
   # Check if source machine exists
   # ---------------------------------------------------------------

--- a/bin/kvm-list-templates
+++ b/bin/kvm-list-templates
@@ -7,10 +7,11 @@ import subprocess
 import logging
 import optparse
 
+from socket import gethostname
 from proxmox_utils import KVMUtils, ShellUtils
                     
 def main():
-  paths = os.listdir('/etc/qemu-server')
+  paths = os.listdir('/etc/pve/nodes/%s/qemu-server' % gethostname())
   REGEX_TEMPLATE = '^t_([^.]+)\.conf$'
   
   print "Available KVM templates:"

--- a/proxmox_utils/proxmox_utils.py
+++ b/proxmox_utils/proxmox_utils.py
@@ -1,12 +1,13 @@
 import os
 from shell_utils import ShellUtils
+from socket import gethostname
 
 class KVMUtils(object):
   REGEX_TEMPLATE_NAME = '^[a-zA-Z0-9_-]+$'
   
   @classmethod
   def config_path(cls, vm_id):
-    return "/etc/qemu-server/%s.conf" % vm_id
+    return "/etc/pve/nodes/%s/qemu-server/%s.conf" % (gethostname(), vm_id)
     
   @classmethod
   def image_path(cls, vm_id):


### PR DESCRIPTION
Proxmox 1 used /etc/qemu-server for storing configuration files. Starting with Proxmox 2 the files are managed
through the Proxmox Cluster file system (pmxcfs) inside /etc/pve/nodes/$HOSTNAME/qemu-server, see
http://pve.proxmox.com/wiki/Proxmox_Cluster_file_system_%28pmxcfs%29 for details.

I'm using this on a Proxmox cluster version 2.1-13. If support for Proxmox 1 versions is still worthwhile in your opinion it might be worth checking for the according Proxmox version and then adjust the directories accordingly on the fly, the patch should give you an idea what to do. :)

Thanks for proxmox-utils! :)
